### PR TITLE
Extra check for double-height crops

### DIFF
--- a/src/main/java/enemeez/simplefarming/block/growable/DoubleCropBlock.java
+++ b/src/main/java/enemeez/simplefarming/block/growable/DoubleCropBlock.java
@@ -58,8 +58,12 @@ public class DoubleCropBlock extends CropsBlock {
 				if (net.minecraftforge.common.ForgeHooks.onCropsGrowPre(worldIn, pos, state,
 						random.nextInt((int) (25.0F / f) + 1) == 0)) {
 					if (i == 6) {
-						if (worldIn.getBlockState(pos.up()) == Blocks.AIR.getDefaultState())
+						if (worldIn.getBlockState(pos.up()) == Blocks.AIR.getDefaultState() &&
+						worldIn.getBlockState(pos.down()).getBlock() == Blocks.FARMLAND) {
 							worldIn.setBlockState(pos.up(), this.withAge(7), 2);
+						} else if (worldIn.getBlockState(pos.down()) == this.withAge(6)) {
+							worldIn.setBlockState(pos, this.withAge(7), 2);
+						}
 					} else
 						worldIn.setBlockState(pos, this.withAge(i + 1), 2);
 					net.minecraftforge.common.ForgeHooks.onCropsGrowPost(worldIn, pos, state);


### PR DESCRIPTION
Extra check to avoid glitches with other mods doing their own version of auto-harvest on double-height crops.

Some other mods that do an auto-harvest/replant don't expect a crop to be double height. If you use these and harvest the top part of the double-height crops (corn etc.) they remove just the top part and "replant" at an offset of one block too high. This then tries to grow two high from there which causes triple height plants which then immediately break off throwing corn on the ground everywhere.

This patch looks redundant, but it just does an extra check when trying to perform the stage 7 growth - Am I actually on the ground? If so grow above as usual. If not just change my own stage 6 to stage 7.

There are other ways to solve this problem but I found this the simplest without any overhead checking for block changes all the time etc.